### PR TITLE
Update test following pika major version change.

### DIFF
--- a/catalog.tests.bom
+++ b/catalog.tests.bom
@@ -92,9 +92,7 @@ brooklyn.catalog:
                   f.write(" [x] Received %r" % body)
                   f.close()
                   print(' [*] Writing message to out.txt')
-              channel.basic_consume(callback,
-                                    queue='hello',
-                                    no_ack=True)
+              channel.basic_consume('hello', callback, auto_ack=False)
               print(' [*] Waiting for messages. To exit press CTRL+C')
               channel.start_consuming()
               EOM


### PR DESCRIPTION
In Version 1.0.0 of Pika (released 26/3/19) the signature of the 'basic_consume' method was changed. The function call in the test has been updated to reflect this.